### PR TITLE
Nerf WWs sneak

### DIFF
--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
@@ -118,7 +118,7 @@
 	W.mind.adjust_skillrank(/datum/skill/combat/wrestling, 5, TRUE)
 	W.mind.adjust_skillrank(/datum/skill/combat/unarmed, 5, TRUE)
 	W.mind.adjust_skillrank(/datum/skill/misc/climbing, 6, TRUE)
-	W.mind.adjust_skillrank(/datum/skill/misc/sneaking, 4, TRUE)
+	W.mind.adjust_skillrank(/datum/skill/misc/sneaking, 2, TRUE)
 	W.mind.adjust_skillrank(/datum/skill/misc/swimming, 3, TRUE)
 
 	if(isseelie(W.stored_mob))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

What it says on the title

## Why It's Good For The Game

Sneak is busted, and werewolves are getting a buff to their straight combat staying power here https://github.com/Rotwood-Vale/Ratwood-Keep/pull/2980


## Proof of Testing (Required)

1 line change
